### PR TITLE
fixed sMetadataVersion

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -9,7 +9,7 @@
 /**
  * Metadata version
  */
-$sMetadataVersion = '2';
+$sMetadataVersion = '2.0';
 
 /**
  * Module information


### PR DESCRIPTION
While updating to Oxid 6.2.0 this error popped up since 2 is not valid sMetadataVersion.

Installing module /var/www/html/source/modules/ab/htmlmin
Module directory of /var/www/html/source/modules/ab/htmlmin  could not be installed due to Metadata version 2 is not supported